### PR TITLE
Enable Dependabot updates for the Dockerfile

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'


### PR DESCRIPTION
The current base image is very old by now, prevent that from happening again. :sweat_smile: 