### PR TITLE
Replace --force, removed in sarif-multitool 4.1.0

### DIFF
--- a/action.bash
+++ b/action.bash
@@ -8,4 +8,4 @@ output="$(realpath "${INPUT_SARIF_FILE}")"
 # must be in the action directory to use the npm packages installed there
 cd "$(dirname ${0})"
 npx "@microsoft/sarif-multitool" convert "${input}" \
-    --tool "${tool}" --output "${output}" --force
+    --tool "${tool}" --output "${output}" --log ForceOverwrite

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
 	"url": "https://github.com/airtower-luna/convert-to-sarif.git"
     },
     "dependencies": {
-	"@microsoft/sarif-multitool": "^4.0.0"
+	"@microsoft/sarif-multitool": "^4.1.0"
     }
 }


### PR DESCRIPTION
The option was removed before the 4.1.0 release (https://github.com/microsoft/sarif-sdk/pull/2625) causing this action to break, unfortunately the documentation wasn't updated until significantly later (https://github.com/microsoft/sarif-sdk/pull/2656).