### PR TITLE
Commit NPM lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,72 @@
+{
+    "name": "convert-to-sarif",
+    "version": "0.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "convert-to-sarif",
+            "version": "0.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/sarif-multitool": "^4.1.0"
+            }
+        },
+        "node_modules/@microsoft/sarif-multitool": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool/-/sarif-multitool-4.1.0.tgz",
+            "integrity": "sha512-KG95HSNH6BGe0hOTF09JRjForKx71i5KPK/5Io5qX1EqcHlwR0Zx2kbCujuMp5P4NY1w0dUTGb0kuucGwXhetg==",
+            "os": [
+                "darwin",
+                "linux",
+                "win32"
+            ],
+            "bin": {
+                "sarif-multitool": "bin.js"
+            },
+            "optionalDependencies": {
+                "@microsoft/sarif-multitool-darwin": "^4.1.0",
+                "@microsoft/sarif-multitool-linux": "^4.1.0",
+                "@microsoft/sarif-multitool-win32": "^4.1.0"
+            }
+        },
+        "node_modules/@microsoft/sarif-multitool-darwin": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-darwin/-/sarif-multitool-darwin-4.1.0.tgz",
+            "integrity": "sha512-Ty0zVO5sIQOqYr3ftXPCZ+61tT1V0vSnQIs5AW3/c78fBMaGlEMn+Fma+qCgi/fwBo2mxNuATi+8rguI6rzg2g==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "bin": {
+                "sarif-multitool-darwin": "bin.js"
+            }
+        },
+        "node_modules/@microsoft/sarif-multitool-linux": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-linux/-/sarif-multitool-linux-4.1.0.tgz",
+            "integrity": "sha512-HMHFxVUVCk3lUuuyImF63o0zsk2q5DHl0O+VbZF0ofTnLxtQ+Awxmc4+IcT331+Ov9OW2G9wG8Dqr2fynRLItg==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "bin": {
+                "sarif-multitool-linux": "bin.js"
+            }
+        },
+        "node_modules/@microsoft/sarif-multitool-win32": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-win32/-/sarif-multitool-win32-4.1.0.tgz",
+            "integrity": "sha512-XCj5bkD3YnqIwF5nycKGdL5CH7Yk3d+Q7Hz2P98k2VCEHqk38kSBHH4bV80DvDPHCq8CVtLgRQOk39a29EQgvA==",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "bin": {
+                "sarif-multitool-win32": "bin.js"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This should avoid surprises like getting sarif-multitool 4.1.0 instead of 4.0.0 with its breaking change (see #10), instead Dependabot should handle updates.